### PR TITLE
Implement returns methods, some reorg

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2023-05-16
+- Implement NotImplemented returns/metrics methods for single index
+- add more power to the secapi mocker; can now also mock session level methods
+- add intraday support
+- kill get_client from secapi and move module
+- add logging to the secapi mocker
+
 ## [0.7.0] - 2023-05-15
 - add class for managing a single index
 - more tests

--- a/merqube_client_lib/api_client/base.py
+++ b/merqube_client_lib/api_client/base.py
@@ -3,7 +3,8 @@ Base class for all Merqube API Clients
 """
 from typing import Any, Iterable, Optional
 
-from merqube_client_lib.session import MerqubeAPISession, get_merqube_session
+# import like this so monkeypatch works as expected
+from merqube_client_lib import session
 from merqube_client_lib.types import ManifestList
 
 
@@ -14,11 +15,11 @@ class MerqubeApiClientBase:
 
     def __init__(
         self,
-        user_session: Optional[MerqubeAPISession] = None,
+        user_session: Optional[session.MerqubeAPISession] = None,
         token: Optional[str] = None,
         **session_kwargs: Any,
     ):
-        self.session = user_session or get_merqube_session(token=token, **session_kwargs)
+        self.session = user_session or session.get_merqube_session(token=token, **session_kwargs)
 
     def _collection_helper(
         self,

--- a/merqube_client_lib/api_client/secapi.py
+++ b/merqube_client_lib/api_client/secapi.py
@@ -8,7 +8,7 @@ from collections import abc
 from typing import Any, Iterable, Optional
 
 import pandas as pd
-from cachetools import LRUCache, TTLCache, cached, cachedmethod
+from cachetools import TTLCache, cachedmethod
 
 from merqube_client_lib.api_client.base import MerqubeApiClientBase
 from merqube_client_lib.constants import DEFAULT_CACHE_TTL
@@ -41,7 +41,7 @@ class SecAPIClient(MerqubeApiClientBase):
         """
         Get the list of supported security types
         """
-        return self.session.get_collection("/security")
+        return self.session.get_collection(url="/security")
 
     @cachedmethod(operator.attrgetter("type_cache"))
     def _validate_secapi_type(self, sec_type: str) -> None:
@@ -279,16 +279,3 @@ class SecAPIClient(MerqubeApiClientBase):
             .reset_index()
             .drop("index", axis=1)
         )
-
-
-secapi_client_cache: LRUCache = LRUCache(maxsize=256)  # type: ignore
-
-
-@cached(cache=secapi_client_cache)
-def get_client(
-    user_session: Optional[MerqubeAPISession] = None, token: Optional[str] = None, **session_kwargs: Any
-) -> SecAPIClient:
-    """
-    Cached; returns a secapi client for token
-    """
-    return SecAPIClient(user_session=user_session, token=token, **session_kwargs)

--- a/merqube_client_lib/mocker.py
+++ b/merqube_client_lib/mocker.py
@@ -85,7 +85,7 @@ def mock_secapi_builder(
         if session_func_map is not None:
             for method_name, func in session_func_map.items():
                 if getattr(sess, method_name) is None:
-                    raise ValueError("Trying to patch a function that doesnt exist in the session")
+                    raise ValueError(f"Trying to patch a nonexisting session method: {method_name}")
                 logger.debug(f"Mocking session method {method_name}")
                 setattr(sess, method_name, func)
 
@@ -103,7 +103,7 @@ def mock_secapi_builder(
 
         for method_name, func in method_name_function_map.items():
             if getattr(client, method_name) is None:
-                raise ValueError("Trying to patch a function that doesnt exist in the client")
+                raise ValueError(f"Trying to patch a nonexisting client method: {method_name}")
             logger.debug(f"Mocking method {method_name}")
             setattr(client, method_name, func)
 

--- a/merqube_client_lib/session.py
+++ b/merqube_client_lib/session.py
@@ -302,12 +302,3 @@ def get_merqube_session(token: str | None = None, **session_args: Any) -> Merqub
     Cached; returns a session with the given token
     """
     return MerqubeAPISession(token=token, **session_args)
-
-
-@cached(cache=LRUCache(maxsize=1))
-def get_public_merqube_session() -> MerqubeAPISession:
-    """
-    Returns a (no token) session.
-    This can be used to access all data in the `default` namespace (world viewable)
-    """
-    return MerqubeAPISession()

--- a/poetry.lock
+++ b/poetry.lock
@@ -231,6 +231,30 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "exchange-calendars"
+version = "4.2.7"
+description = "Calendars for securities exchanges"
+category = "main"
+optional = false
+python-versions = "~=3.8"
+files = [
+    {file = "exchange_calendars-4.2.7-py3-none-any.whl", hash = "sha256:55111d133955afbd6d2306d160f80da0fed66146eb8affca31c51408ad8695e6"},
+    {file = "exchange_calendars-4.2.7.tar.gz", hash = "sha256:fec2926595abd4fdeb10fe2c091f0ff8ad7309381efad34725f342eac10f1203"},
+]
+
+[package.dependencies]
+korean-lunar-calendar = "*"
+numpy = "*"
+pandas = ">=1.1"
+pyluach = "*"
+python-dateutil = "*"
+pytz = "*"
+toolz = "*"
+
+[package.extras]
+dev = ["flake8", "hypothesis", "pip-tools", "pytest", "pytest-benchmark", "pytest-xdist"]
+
+[[package]]
 name = "execnet"
 version = "1.9.0"
 description = "execnet: rapid multi-Python deployment"
@@ -368,6 +392,18 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "korean-lunar-calendar"
+version = "0.3.1"
+description = "Korean Lunar Calendar"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "korean_lunar_calendar-0.3.1-py3-none-any.whl", hash = "sha256:392757135c492c4f42a604e6038042953c35c6f449dda5f27e3f86a7f9c943e5"},
+    {file = "korean_lunar_calendar-0.3.1.tar.gz", hash = "sha256:eb2c485124a061016926bdea6d89efdf9b9fdbf16db55895b6cf1e5bec17b857"},
+]
 
 [[package]]
 name = "markupsafe"
@@ -587,6 +623,24 @@ pytz = ">=2020.1"
 test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
+name = "pandas-market-calendars"
+version = "4.1.4"
+description = "Market and exchange trading calendars for pandas"
+category = "main"
+optional = false
+python-versions = ">=3.8.0"
+files = [
+    {file = "pandas_market_calendars-4.1.4-py3-none-any.whl", hash = "sha256:90f331ac12287366eb72c269484965ea4dcfe2ae928d0ad249fc14230fe72d1f"},
+    {file = "pandas_market_calendars-4.1.4.tar.gz", hash = "sha256:552a3ba082e4e316513d86188f32a3075f449947ba3871fc708be64baabd4614"},
+]
+
+[package.dependencies]
+exchange-calendars = ">=3.3"
+pandas = ">=1.1"
+python-dateutil = "*"
+pytz = "*"
+
+[[package]]
 name = "pdbpp"
 version = "0.10.3"
 description = "pdb++, a drop-in replacement for pdb"
@@ -729,6 +783,22 @@ files = [
 
 [package.extras]
 plugins = ["importlib-metadata"]
+
+[[package]]
+name = "pyluach"
+version = "2.2.0"
+description = "A Python package for dealing with Hebrew (Jewish) calendar dates."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pyluach-2.2.0-py3-none-any.whl", hash = "sha256:d1eb49d6292087e9290f4661ae01b60c8c933704ec8c9cef82673b349ff96adf"},
+    {file = "pyluach-2.2.0.tar.gz", hash = "sha256:9063a25387cd7624276fd0656508bada08aa8a6f22e8db352844cd858e69012b"},
+]
+
+[package.extras]
+doc = ["sphinx (>=6.1.3,<6.2.0)", "sphinx_rtd_theme (>=1.2.0,<1.3.0)"]
+test = ["beautifulsoup4", "flake8", "pytest", "pytest-cov"]
 
 [[package]]
 name = "pyreadline"
@@ -937,6 +1007,18 @@ files = [
 ]
 
 [[package]]
+name = "toolz"
+version = "0.12.0"
+description = "List processing tools and functional utilities"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "toolz-0.12.0-py3-none-any.whl", hash = "sha256:2059bd4148deb1884bb0eb770a3cde70e7f954cfbbdc2285f1f2de01fd21eb6f"},
+    {file = "toolz-0.12.0.tar.gz", hash = "sha256:88c570861c440ee3f2f6037c4654613228ff40c93a6c25e0eba70d17282c6194"},
+]
+
+[[package]]
 name = "types-cachetools"
 version = "5.3.0.5"
 description = "Typing stubs for cachetools"
@@ -1116,4 +1198,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10,<4.0"
-content-hash = "88a02a08415f79bc89e8fd16e9410dc5e5f2badba931a1b8a96616349b33b418"
+content-hash = "45cf32b518759b17ec3754705ab98289a5a1ae9a3a561606afe06a9d3077534f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "merqube-client-lib"
-version = "0.7.0"
+version = "0.8.0"
 description = "MerQube IndexAPI + SecAPI client library"
 authors = ["Merqube"]
 readme = "README.md"
@@ -18,6 +18,7 @@ pandas = "^1.3.0"
 Flask = "~2"
 Flask-Cors = "~3"
 cachetools = "^5.2.0"
+pandas_market_calendars = "*"
 
 [tool.poetry.dev-dependencies]
 coverage =  {version="*"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,12 +5,11 @@ import pytest
 
 from merqube_client_lib.api_client import merqube_client
 from merqube_client_lib.mocker import mock_secapi_builder
-from merqube_client_lib.secapi import client
 
 mock_secapi = mock_secapi_builder(
     get_session_function_path="merqube_client_lib.session.get_merqube_session",
-    get_client_function_path="merqube_client_lib.secapi.client.get_client",
-    secapi_client_cache=client.secapi_client_cache,
+    get_client_function_path="merqube_client_lib.api_client.merqube_client.get_client",
+    secapi_client_cache=merqube_client.client_cache,
 )
 
 

--- a/tests/integration/test_indexapi_client_single.py
+++ b/tests/integration/test_indexapi_client_single.py
@@ -132,9 +132,28 @@ def test_single_intraday_index_return():
     12  2023-05-15T19:01:00  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.227063
     """
 
-    df = client.get_returns(start_date=start_date, end_date=end_date)
+    df = client.get_returns(start_date=start_date, end_date=end_date, use_intraday_metrics=True)
     assert not df.empty
-    assert len(df["price_return"].tolist())
+    assert len(df["price_return"].tolist()) > 2
+
+    # EOD we can test a fixed window
+    df = client.get_returns(
+        start_date=pd.Timestamp("2023-05-12"), end_date=pd.Timestamp("2023-05-15"), use_intraday_metrics=False
+    )
+    assert df.to_dict(orient="records") == [
+        {
+            "eff_ts": "2023-05-12T00:00:00",
+            "id": "27514b7a-3575-4da1-a1f1-c22d0e361c78",
+            "name": "MQUSTRAV",
+            "price_return": 1926.1529634388705,
+        },
+        {
+            "eff_ts": "2023-05-15T00:00:00",
+            "id": "27514b7a-3575-4da1-a1f1-c22d0e361c78",
+            "name": "MQUSTRAV",
+            "price_return": 1950.7413459671484,
+        },
+    ]
 
 
 def test_single_index_multiple_metrics():

--- a/tests/integration/test_indexapi_client_single.py
+++ b/tests/integration/test_indexapi_client_single.py
@@ -1,23 +1,25 @@
+import pandas as pd
+import pandas_market_calendars as mcal
 import pytest
 from pydantic import BaseModel
 
 from merqube_client_lib.api_client.merqube_client import MerqubeAPIClientSingleIndex
 from merqube_client_lib.exceptions import APIError
-from merqube_client_lib.session import get_public_merqube_session
+from merqube_client_lib.session import get_merqube_session
 
 
 def test_nonexistent():
     with pytest.raises(APIError):
-        MerqubeAPIClientSingleIndex(index_name="thisdoesnotexist", user_session=get_public_merqube_session())
+        MerqubeAPIClientSingleIndex(index_name="thisdoesnotexist", user_session=get_merqube_session())
 
 
-def test_single():
+def test_single_index_operations():
     """
     Full example using:
     https://merqube.com/index/MQEFAB01
     https://api.merqube.com/index?name=MQEFAB01
     """
-    client = MerqubeAPIClientSingleIndex(index_name="MQEFAB01", user_session=get_public_merqube_session())
+    client = MerqubeAPIClientSingleIndex(index_name="MQEFAB01", user_session=get_merqube_session())
 
     assert isinstance(client.get_index_manifest(), dict)
 
@@ -53,3 +55,148 @@ def test_single():
         assert k in stats[0]
 
     # target portfolios and data collections are not available for this index
+
+
+def test_single_index_returns():
+    """
+    Full example using:
+    https://merqube.com/index/MQEFAB01
+    https://api.merqube.com/index?name=MQEFAB01
+    """
+    client = MerqubeAPIClientSingleIndex(index_name="MQEFAB01", user_session=get_merqube_session())
+    df = client.get_returns(start_date=pd.Timestamp("2023-04-01"), end_date=pd.Timestamp("2023-05-01"))
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+
+    sid = "d84bc0d3-7788-4fed-9283-049eadab8964"
+    assert df.to_dict(orient="records") == [
+        {"eff_ts": "2023-04-03T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2061.3759657505516},
+        {"eff_ts": "2023-04-04T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2058.4726656406847},
+        {"eff_ts": "2023-04-05T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2052.2820122315807},
+        {"eff_ts": "2023-04-06T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2060.1335590375693},
+        {"eff_ts": "2023-04-10T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2060.2625642018947},
+        {"eff_ts": "2023-04-11T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2065.2562703626586},
+        {"eff_ts": "2023-04-12T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2070.291345358123},
+        {"eff_ts": "2023-04-13T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2092.4128224566343},
+        {"eff_ts": "2023-04-14T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2088.767771842511},
+        {"eff_ts": "2023-04-17T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2084.5264838309063},
+        {"eff_ts": "2023-04-18T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2091.8147254568066},
+        {"eff_ts": "2023-04-19T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2090.477285497472},
+        {"eff_ts": "2023-04-20T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2085.844141746835},
+        {"eff_ts": "2023-04-21T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2093.9443207973086},
+        {"eff_ts": "2023-04-24T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2100.3887653420798},
+        {"eff_ts": "2023-04-25T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2078.0373192902475},
+        {"eff_ts": "2023-04-26T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2077.5464610492604},
+        {"eff_ts": "2023-04-27T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2094.681756502886},
+        {"eff_ts": "2023-04-28T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2084.1597797916966},
+        {"eff_ts": "2023-05-01T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2097.136207320045},
+    ]
+
+
+def test_single_intraday_index_return():
+    """
+    MQUSTRAV realtime ("intraday") index
+    """
+    client = MerqubeAPIClientSingleIndex(index_name="MQUSTRAV", is_intraday=True, user_session=get_merqube_session())
+
+    # RT indices only store 5 second ticks for 7 business days
+    # get the last trading day before today
+    nyse = mcal.get_calendar("NYSE")
+    today = pd.Timestamp.now(tz="America/New_York").date()
+    # nyse should never have a block of 6 days off
+    sched = nyse.schedule(start_date=today - pd.Timedelta(days=6), end_date=today)
+    ltd = sched.index.to_list()[-2]
+
+    # form a 1 minute trading window, the index ticks every 5 seconds
+    start_date = pd.Timestamp(year=ltd.year, month=ltd.month, day=ltd.day, hour=19, minute=0, second=0)  # UTC time
+    end_date = pd.Timestamp(year=ltd.year, month=ltd.month, day=ltd.day, hour=19, minute=1, second=0)
+
+    """
+    We dont assert a value since the window of data changes every night, we just assert nonempty. 
+    Example of an actual df:
+
+                     eff_ts                                    id      name  price_return
+    0   2023-05-15T19:00:00  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.487644
+    1   2023-05-15T19:00:05  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.295987
+    2   2023-05-15T19:00:10  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.294829
+    3   2023-05-15T19:00:15  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.363435
+    4   2023-05-15T19:00:20  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.339992
+    5   2023-05-15T19:00:25  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.339992
+    6   2023-05-15T19:00:30  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.255751
+    7   2023-05-15T19:00:35  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.268566
+    8   2023-05-15T19:00:40  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.266249
+    9   2023-05-15T19:00:45  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.253435
+    10  2023-05-15T19:00:50  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.197780
+    11  2023-05-15T19:00:55  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.192617
+    12  2023-05-15T19:01:00  e0825ead-bb51-40c4-8130-76a1d44c368d  MQUSTRAV   1948.227063
+    """
+
+    df = client.get_returns(start_date=start_date, end_date=end_date)
+    assert not df.empty
+    assert len(df["price_return"].tolist())
+
+
+def test_single_index_multiple_metrics():
+    """
+    Full example using:
+    https://merqube.com/index/MQ2Q0BQR
+    https://api.merqube.com/index?name=MQ2Q0BQR
+    """
+    client = MerqubeAPIClientSingleIndex(index_name="MQ2Q0BQR", user_session=get_merqube_session())
+
+    mets = ["price_return", "daily_return", "net_total_return", "total_return"]
+
+    df = client.get_metrics(metrics=mets, start_date=pd.Timestamp("2023-04-01"), end_date=pd.Timestamp("2023-04-10"))
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+
+    sid = "f056cf50-1f75-4fae-87d6-230e2d676975"
+    assert df.to_dict(orient="records") == [
+        {
+            "daily_return": -0.001490379831880495,
+            "eff_ts": "2023-04-03T00:00:00",
+            "id": sid,
+            "name": "MQ2Q0BQR",
+            "net_total_return": 7435.441291840737,
+            "price_return": 7435.441291840617,
+            "total_return": 7435.441291840737,
+        },
+        {
+            "daily_return": -0.0023339663506358743,
+            "eff_ts": "2023-04-04T00:00:00",
+            "id": sid,
+            "name": "MQ2Q0BQR",
+            "net_total_return": 7418.087222063452,
+            "price_return": 7418.087222063333,
+            "total_return": 7418.087222063452,
+        },
+        {
+            "daily_return": -0.00802688787903727,
+            "eff_ts": "2023-04-05T00:00:00",
+            "id": sid,
+            "name": "MQ2Q0BQR",
+            "net_total_return": 7358.5430676550295,
+            "price_return": 7358.543067654911,
+            "total_return": 7358.5430676550295,
+        },
+        {
+            "daily_return": 0.005579187693722787,
+            "eff_ts": "2023-04-06T00:00:00",
+            "id": sid,
+            "name": "MQ2Q0BQR",
+            "net_total_return": 7399.59776058182,
+            "price_return": 7399.597760581701,
+            "total_return": 7399.59776058182,
+        },
+        {
+            "daily_return": 0.0009701824776102708,
+            "eff_ts": "2023-04-10T00:00:00",
+            "id": sid,
+            "name": "MQ2Q0BQR",
+            "net_total_return": 7406.7767206705,
+            "price_return": 7406.776720670382,
+            "total_return": 7406.7767206705,
+        },
+    ]

--- a/tests/integration/test_secapi_client.py
+++ b/tests/integration/test_secapi_client.py
@@ -9,7 +9,7 @@ from functools import partial
 import pandas as pd
 import pytest
 
-from merqube_client_lib.secapi.client import get_client
+from merqube_client_lib.api_client.merqube_client import get_client
 from tests.unit.fixtures.gsm_fixtures import (
     mult_mult_assertion,
     mult_sing_assertion,
@@ -27,7 +27,7 @@ def test_mapping_table():
 
     for k, v in {
         "NWSALTVI": "2963d69a-2c81-4ee5-9c0e-98fc1e476f2a",
-        "UBCIPACC": "b47bc829-82b4-4610-921f-9dc73936a10b",
+        "MQEFAB01": "d84bc0d3-7788-4fed-9283-049eadab8964",
         "MQUSTRAV": "27514b7a-3575-4da1-a1f1-c22d0e361c78",
     }.items():
         assert all_public_indices[k] == v
@@ -35,18 +35,18 @@ def test_mapping_table():
 
 def test_mapping_table_for_specific_names():
     public = get_client()
-    mt = public.get_security_definitions_mapping_table(sec_type="index", sec_names=["NWSALTVI", "UBCIPACC"])
+    mt = public.get_security_definitions_mapping_table(sec_type="index", sec_names=["NWSALTVI", "MQEFAB01"])
     assert mt["NWSALTVI"] == "2963d69a-2c81-4ee5-9c0e-98fc1e476f2a"
-    assert mt["UBCIPACC"] == "b47bc829-82b4-4610-921f-9dc73936a10b"
+    assert mt["MQEFAB01"] == "d84bc0d3-7788-4fed-9283-049eadab8964"
 
 
 def test_mapping_table_for_specific_ids():
     public = get_client()
     mt = public.get_security_definitions_mapping_table(
-        sec_type="index", sec_ids=["2963d69a-2c81-4ee5-9c0e-98fc1e476f2a", "b47bc829-82b4-4610-921f-9dc73936a10b"]
+        sec_type="index", sec_ids=["2963d69a-2c81-4ee5-9c0e-98fc1e476f2a", "d84bc0d3-7788-4fed-9283-049eadab8964"]
     )
     assert mt["2963d69a-2c81-4ee5-9c0e-98fc1e476f2a"] == "NWSALTVI"
-    assert mt["b47bc829-82b4-4610-921f-9dc73936a10b"] == "UBCIPACC"
+    assert mt["d84bc0d3-7788-4fed-9283-049eadab8964"] == "MQEFAB01"
 
 
 def test_get_metric_defs_for_security():

--- a/tests/integration/test_secapi_client_chunking.py
+++ b/tests/integration/test_secapi_client_chunking.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from merqube_client_lib.secapi.client import get_client
+from merqube_client_lib.api_client.merqube_client import get_client
 from tests.unit.fixtures.gsm_fixtures import TEST_IDS_NE, TEST_METRICS_NE, TEST_NAMES_NE
 
 CHUNK_TESTS = [(1), (2), (3), (4), (5), (6)]

--- a/tests/unit/fixtures/dummy_secapi.py
+++ b/tests/unit/fixtures/dummy_secapi.py
@@ -2,12 +2,12 @@ from unittest.mock import MagicMock
 
 from cachetools import LRUCache, cached
 
-from merqube_client_lib.secapi.client import SecAPIClient
+from merqube_client_lib.api_client.merqube_client import MerqubeAPIClient
 
 client_cache = LRUCache(maxsize=1)
 
 
-class DummyAPIClient(SecAPIClient):
+class DummyAPIClient(MerqubeAPIClient):
     """few addl methods"""
 
     def get_futures_contracts_from_secapi(self):

--- a/tests/unit/test_base_session.py
+++ b/tests/unit/test_base_session.py
@@ -22,7 +22,7 @@ class MockRequestsResponse(object):
 def test_handle_nonrecoverable():
     exc = Exception("test")
 
-    sess = session.get_public_merqube_session()
+    sess = session.get_merqube_session()
     with pytest.raises(APIError) as e:
         sess.handle_nonrecoverable(MockRequestsResponse(500, {"error": "test"}), exc)
 

--- a/tests/unit/test_indexapi_client.py
+++ b/tests/unit/test_indexapi_client.py
@@ -2,10 +2,13 @@
 Unit tests for indexapi
 There are more in the integration tests
 """
+from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
 from merqube_client_lib.api_client.merqube_client import get_client
+from tests.conftest import mock_secapi
 
 valid1 = {"id": "valid1id", "name": "valid1", "stage": "prod"}
 valid2 = {"id": "valid2id", "name": "valid2", "stage": "prod"}
@@ -54,3 +57,43 @@ def test_get_indices(names, expected, inc_nonprod):
     client.session.get_collection = fake_get_collection
 
     assert client.get_index_defs(names, include_nonprod=inc_nonprod) == expected
+
+
+def test_single_index_returns(monkeypatch):
+    """
+    fixed (unit) example using:
+    https://merqube.com/index/MQEFAB01
+    https://api.merqube.com/index?name=MQEFAB01
+    """
+    sid = "testid"
+
+    ret = [
+        {"eff_ts": "2023-04-03T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2061.3759657505516},
+        {"eff_ts": "2023-04-04T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2058.4726656406847},
+        {"eff_ts": "2023-04-05T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2052.2820122315807},
+        {"eff_ts": "2023-04-06T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2060.1335590375693},
+        {"eff_ts": "2023-04-10T00:00:00", "id": sid, "name": "MQEFAB01", "price_return": 2060.2625642018947},
+    ]
+
+    gsm = pd.DataFrame.from_records(ret)
+
+    def mock_get_collection(url, **kwargs):
+        if url == "https://api.merqube.com/index?name=MQEFAB01":
+            return [{"name": "MQEFAB01", "id": sid}]
+        else:
+            return [{"name": "index"}]  # get_security_metrics
+
+    mock_secapi(
+        monkeypatch,
+        method_name_function_map={"get_security_metrics": MagicMock(return_value=gsm)},
+        session_func_map={"get_collection": mock_get_collection},
+        index_name="MQEFAB01",  # get_client_kwargs
+    )
+
+    client = get_client(index_name="MQEFAB01")
+
+    df = client.get_returns(start_date=pd.Timestamp("2023-04-01"), end_date=pd.Timestamp("2023-04-10"))
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert df.to_dict(orient="records") == ret

--- a/tests/unit/test_mocker.py
+++ b/tests/unit/test_mocker.py
@@ -5,9 +5,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from merqube_client_lib.api_client.merqube_client import client_cache, get_client
 from merqube_client_lib.mocker import _sec_types, mock_secapi_builder
-from merqube_client_lib.secapi import client as cl
-from merqube_client_lib.secapi.client import get_client
 from tests.conftest import mock_secapi
 from tests.unit.fixtures.dummy_secapi import get_client as dummy_client
 
@@ -34,7 +33,7 @@ def test_mock_secapi_builder_fail():
 @pytest.mark.parametrize("with_custom_sec_types", [False, True], ids=["default-sec-types", "custom-sec-types"])
 def test_mock_secapi_builder(monkeypatch, with_cache, with_custom_sec_types):
     """test successful mocking using a dummy client"""
-    cache = MagicMock(wraps=cl.secapi_client_cache)
+    cache = MagicMock(wraps=client_cache)
 
     dummy_mocker = mock_secapi_builder(
         get_session_function_path="tests.unit.fixtures.dummy_secapi._get_session",

--- a/tests/unit/test_secapi_base.py
+++ b/tests/unit/test_secapi_base.py
@@ -5,8 +5,7 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from merqube_client_lib.api_client import base
-from merqube_client_lib.secapi import client
+from merqube_client_lib.api_client import base, merqube_client
 
 
 @pytest.mark.parametrize(
@@ -49,7 +48,7 @@ def test_arg_validation(params, func, should_work):
         def __init__(self):
             self.get_collection = ch
 
-    cl = client.SecAPIClient(user_session=mock_session())
+    cl = merqube_client.MerqubeAPIClient(user_session=mock_session())
 
     if should_work:
         getattr(cl, func)(**params)

--- a/tests/unit/test_secapi_client_reads.py
+++ b/tests/unit/test_secapi_client_reads.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pandas.testing import assert_frame_equal
 
-from merqube_client_lib.secapi.client import get_client
+from merqube_client_lib.api_client.merqube_client import get_client
 from tests.conftest import mock_secapi
 from tests.unit.fixtures.gsm_chunked_fixtures import (
     chunked_id,


### PR DESCRIPTION
- Implement NotImplemented returns/metrics methods for single index
- add more power to the secapi mocker; can now also mock session level methods
- kill get_client from secapi and move module
- add intraday support
- add logging to the secapi mocker